### PR TITLE
map port 5432 to allow connections when deploying on local

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - POSTGRES_DB=micro_ai
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
+    ports:
+      - "5432:5432"
     networks:
       - microaiNetwork
     healthcheck:


### PR DESCRIPTION
Largely just a test to test merging changes. @brnikita do you approve this change? I think it only affects local connections and not prod. 