### PR TITLE
fix: #189 - disable api call resulting in 404 and whipping out LiteLLM models list

### DIFF
--- a/frontend/src/app/(authenticated)/app/(pages)/edit/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/app/(pages)/edit/[id]/page.tsx
@@ -194,7 +194,11 @@ const SurveyCreatorRenderComponent: React.FC<SurveyCreatorProps> = ({ hashId }) 
       if (hashId !== null) {
          fetchMicroapp(hashId, signal);
          fetchCollections();
-         fetchModels();
+         
+         //fetchModels();
+         // fetchModels results in 404 error currently
+         // TODO: investigate why the endpoint is missing on
+         // backend & wheather it is needed after LiteLLM integration
       }
 
       return () => {

--- a/frontend/src/app/(authenticated)/app/(pages)/edit/[id]/utils/fetchAvailableModels.ts
+++ b/frontend/src/app/(authenticated)/app/(pages)/edit/[id]/utils/fetchAvailableModels.ts
@@ -52,8 +52,9 @@ export const fetchAvailableModelsSingleton = (): () => Promise<ModelTemperatureR
                resolveAllPendingRequests(modelTemperatureRanges);
             })
             .catch(() => {
-               modelTemperatureRanges = createErrorResponse();
-               resolveAllPendingRequests(modelTemperatureRanges);
+               // TODO: investigate why the endpoint is missing on
+               // backend & wheather it is needed after LiteLLM integration
+               throw new Error("Failed to fetch available models");
             })
             .finally(() => {
                isFetching = false;


### PR DESCRIPTION
Disable api call resulting in 404 and whipping out LiteLLM models list in zustand state.