### PR TITLE
Adjust rubric UI

### DIFF
--- a/frontend/src/app/(authenticated)/app/(pages)/edit/[id]/components/fields/ScoringField.tsx
+++ b/frontend/src/app/(authenticated)/app/(pages)/edit/[id]/components/fields/ScoringField.tsx
@@ -193,7 +193,7 @@ export default function ScoringField({
                 onChange?.(field.id, { minScore: 0 });
               }
             }}
-            className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all"
+            className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
             placeholder="Enter minimum score"
           />
         )}
@@ -238,7 +238,6 @@ export default function ScoringField({
             transition={{ duration: 0.4, ease: [0.4, 0, 0.2, 1] }}
             className="overflow-hidden space-y-3"
           >
-            {" "}
             <div className="flex items-center group/header">
               {!isPreview ? (
                 <div className="flex-1 flex items-center gap-2">
@@ -272,11 +271,23 @@ export default function ScoringField({
                 </span>
               )}
             </div>
-            <div className="border border-gray-200 rounded-lg overflow-hidden bg-white shadow-sm">
+
+            <motion.div
+              layout="position"
+              className={`border rounded-lg overflow-hidden bg-white shadow-sm transition-colors duration-300 ${
+                isPreview
+                  ? "border-gray-200"
+                  : "border-transparent shadow-none rounded-none"
+              }`}
+            >
               <table className="w-full table-fixed border-collapse">
                 <thead>
                   <tr className="bg-gray-50/50 border-b border-gray-200 text-xs text-gray-500 uppercase tracking-wider">
-                    <th className="px-4 py-2 text-left font-medium w-32 border-r border-gray-200">
+                    <th
+                      className={`px-4 py-2 text-center font-medium w-32 ${
+                        isPreview ? "border-r border-gray-200" : ""
+                      }`}
+                    >
                       Score
                     </th>
                     <th className="px-4 py-2 text-left font-medium">
@@ -298,7 +309,7 @@ export default function ScoringField({
                   ))}
                 </tbody>
               </table>
-            </div>
+            </motion.div>
             {!isPreview && (
               <button
                 onClick={() => handleAddLine(catIdx)}

--- a/frontend/src/app/(authenticated)/app/(pages)/edit/[id]/components/ui/ScoringLineRow.tsx
+++ b/frontend/src/app/(authenticated)/app/(pages)/edit/[id]/components/ui/ScoringLineRow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { Button } from "@/app/(authenticated)/app/(pages)/edit/[id]/components/ui/button";
 import { Trash2 } from "lucide-react";
 import {
@@ -6,7 +6,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "./tooltip";
+} from "../ui/tooltip";
 
 export interface ScoringLine {
   score: number | "";
@@ -39,7 +39,7 @@ const ScoringLineRow: React.FC<ScoringLineRowProps> = ({
   const descRef = useRef<HTMLTextAreaElement>(null);
 
   // Sync height of score and description fields
-  const adjustHeight = () => {
+  const adjustHeight = useCallback(() => {
     if (isPreview) return;
 
     const scoreEl = scoreRef.current;
@@ -55,15 +55,15 @@ const ScoringLineRow: React.FC<ScoringLineRowProps> = ({
 
     scoreEl.style.height = `${newHeight}px`;
     descEl.style.height = `${newHeight}px`;
-  };
+  }, [isPreview]);
 
   useEffect(() => {
     adjustHeight();
-  }, [line.description]);
+  }, [line.description, adjustHeight]);
 
   return (
     <tr className="group border-b border-gray-200 last:border-0 hover:bg-gray-50 transition-colors relative">
-      <td className="p-0 w-32 align-middle relative transition-colors text-center">
+      <td className="p-0 w-32 align-top relative transition-colors text-center">
         {!isPreview ? (
           <>
             <div className="relative w-full h-full">
@@ -85,8 +85,8 @@ const ScoringLineRow: React.FC<ScoringLineRowProps> = ({
                     handleLineChange(catIdx, lineIdx, line.description, 0);
                   }
                 }}
-                className="w-full h-full bg-transparent border-none outline-none focus:ring-0 focus:bg-white px-4 py-3 text-sm font-bold resize-none m-0 text-gray-900 placeholder:text-gray-300 text-center"
-                style={{ minHeight: "48px", boxSizing: "border-box" }}
+                className="w-full h-full bg-transparent border-none outline-none focus:ring-0 focus:bg-white px-4 py-3 text-sm font-bold resize-none m-0 text-gray-900 placeholder:text-gray-300 text-center [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none h-[48px]"
+                style={{ boxSizing: "border-box" }}
                 placeholder="0"
               />
             </div>


### PR DESCRIPTION
- Updated table styling to match Figma (minimalistic design in edit mode, fixed backgrounds).
- Added a smooth transition animation for table when switching to edit mode
- Fixed score alignment issues (prevented the number from jumping to the center when text wraps).
- Implemented score guessing for new lines (based on the previous value)
- New categories now initialize with 2 lines by default.

https://github.com/user-attachments/assets/01eb58ad-a591-45de-abd3-27e47e1fc4b3

