### PR TITLE
fix skipping to the next phase when scoring is not required

### DIFF
--- a/frontend/src/app/(authenticated)/app/(pages)/edit/[id]/components/FormBuilder.tsx
+++ b/frontend/src/app/(authenticated)/app/(pages)/edit/[id]/components/FormBuilder.tsx
@@ -518,6 +518,7 @@ export default function FormBuilder() {
           },
         ]),
         minScore: 0,
+        isRequired: true,
       }),
       ...(type === "imageUpload" && {
         multiple: false,

--- a/frontend/src/components/CurrentElementFlow.tsx
+++ b/frontend/src/components/CurrentElementFlow.tsx
@@ -229,7 +229,8 @@ export default function CurrentElementFlow({
         }
       );
 
-      if (res.run_passed === false) return;
+      const scoringIsRequired = stopElement.isRequired !== false;
+      if (res.run_passed === false && scoringIsRequired) return;
       advance(stopIndex + 1);
       return;
     }
@@ -316,6 +317,12 @@ export default function CurrentElementFlow({
           currentConversation?.runs
             ?.filter((run) => run.phaseIndex === idx)
             .sort((a, b) => b.createdAt - a.createdAt)[0] || null;
+        const scoringIsRequired =
+          element.type === "scoring" ? element.isRequired !== false : false;
+        const scoringFailed =
+          element.type === "scoring" && runForThisStop
+            ? !passedTheRubricMinScore(runForThisStop)
+            : false;
 
         const revealedFixed =
           element.type === "fixedResponse"
@@ -440,7 +447,7 @@ export default function CurrentElementFlow({
                   <div className="mt-4">
                     <SkeletonLoader />
                   </div>
-                ) : (
+                ) : element.type === "scoring" && scoringIsRequired && scoringFailed ? null : (
                   <div className="mt-4 flex justify-end">
                     <button
                       type="submit"

--- a/frontend/src/utils/migrateAppJson.ts
+++ b/frontend/src/utils/migrateAppJson.ts
@@ -120,7 +120,7 @@ export function migratePhasesToElements(appJson: any): AppJsonV2 {
         type: 'scoring',
         name: `scoring${scoringCount}`,
         label: '',
-        isRequired: false,
+        isRequired: phase?.skipPhase ? false : true,
         rubric: isNonEmptyString(phase?.rubric) ? phase.rubric : '',
         minScore: typeof phase?.minScore === 'number' ? phase.minScore : 0,
       });


### PR DESCRIPTION
- show "Continue" only if the scoring is not required (old skipPhase: true)
- advance the student to the next fields on "Continue" click after failed min score
- during migration, add required: true for the scoring element in case the phase was scored
- by default, add scoring element with required:true in builder