### PR TITLE
fix completion message removing all prior fileds from the view

### DIFF
--- a/frontend/src/components/CurrentElementFlow.tsx
+++ b/frontend/src/components/CurrentElementFlow.tsx
@@ -238,23 +238,11 @@ export default function CurrentElementFlow({
 
   if (!surveyJson) return null;
 
-  if (cursor >= appElements.length) {
-    return (
-      <div className="space-y-4">
-        <div
-          className="prose max-w-none"
-          dangerouslySetInnerHTML={{
-            __html: surveyJson.completedHtml || "You've reached the end.",
-          }}
-        />
-      </div>
-    );
-  }
+  const isComplete = cursor >= appElements.length;
 
-  const visibleElements = appElements.slice(
-    0,
-    Math.min(visibleUntil + 1, appElements.length)
-  );
+  const visibleElements = isComplete
+    ? appElements
+    : appElements.slice(0, Math.min(visibleUntil + 1, appElements.length));
 
   return (
     <form onSubmit={handleRun} className="space-y-6">
@@ -496,7 +484,7 @@ export default function CurrentElementFlow({
       })}
 
       {/* No stop element left → end */}
-      {!stopElement && stopIndex === null && (
+      {!isComplete && !stopElement && stopIndex === null && (
         <div className="mt-6 flex justify-end">
           <button
             type="button"


### PR DESCRIPTION
Before:
- once the last ai-response is done generating - everything disappears from the user's view. Only the "Completion Message" is shown (from the app's settings)

Now:
- the "Completion Message" is shown below the whole survey