### PR TITLE
Redesign and update messages rendering for conversations on statistic page

### DIFF
--- a/backend/apps/microapps/llm_interface.py
+++ b/backend/apps/microapps/llm_interface.py
@@ -3,7 +3,6 @@ import litellm
 import logging
 from apps.utils.global_variables import UsageVariables
 from .dynamic_model_service import DynamicModelService
-import re
 import tempfile
 import os
 from litellm import speech
@@ -489,25 +488,20 @@ class UnifiedLLMInterface:
             return {"status": False, "message": str(e)}
 
     
-    def extract_score(self, response: str) -> int:
+    def extract_score(self, response: str) -> float:
         """
-        Extract the total score from a JSON-formatted response string.
-        
-        Args:
-            response: The response string containing a JSON object with a 'total' field
-            
-        Returns:
-            The total score as an integer, or 0 if no valid score found
+        Extract the total score from a JSON-formatted response string (or dict).
+
+        Handles prose + fenced JSON from models that narrate before outputting JSON.
         """
         try:
-            pattern = r'"total":\s*"?(\d+)"?'
-            match = re.search(pattern, response)
-            if match:
-                return int(match.group(1))
-            return 0
+            from .score_utils import parse_run_score_total
+
+            v = parse_run_score_total(response)
+            return float(v) if v is not None else 0.0
         except Exception as e:
             log.error(f"Error extracting score: {str(e)}")
-            return 0
+            return 0.0
 
     def build_instruction(self, data: Dict[str, Any], messages: list) -> list:
         """

--- a/backend/apps/microapps/migrations/0065_run_phase_title.py
+++ b/backend/apps/microapps/migrations/0065_run_phase_title.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("microapps", "0064_appthemesnapshot"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="run",
+            name="phase_title",
+            field=models.CharField(blank=True, default="", max_length=255),
+        ),
+        migrations.AddField(
+            model_name="run",
+            name="is_chat_run",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/apps/microapps/models.py
+++ b/backend/apps/microapps/models.py
@@ -185,7 +185,12 @@ class Run(models.Model):
     system_prompt = models.JSONField()
     
     phase_instructions = models.JSONField()
-    
+
+    # Survey phase title at run time (e.g. chat phase label in analytics / conversation details).
+    phase_title = models.CharField(max_length=255, blank=True, default="")
+    # True when this run originates from the chat component.
+    is_chat_run = models.BooleanField(default=False)
+
     user_prompt = models.JSONField()
 
     # The chat response from the AI for the run. Or, a static response if no_submission or skipped_run is true. 

--- a/backend/apps/microapps/score_utils.py
+++ b/backend/apps/microapps/score_utils.py
@@ -1,0 +1,98 @@
+"""
+Parse numeric totals from Run.run_score (JSONField).
+
+Models may store the raw LLM string (prose + fenced JSON) instead of a dict;
+pass/fail logic and analytics need a consistent numeric total.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Optional
+
+_TOTAL_IN_JSON_RE = re.compile(r'"total"\s*:\s*"?([\d.]+)"?', re.IGNORECASE)
+_TOTAL_PROSE_RE = re.compile(r"\btotal\s*:\s*([\d.]+)\b", re.IGNORECASE)
+_FENCED_JSON_RE = re.compile(r"```(?:json)?\s*([\s\S]*?)\s*```", re.IGNORECASE)
+
+
+def _coerce_total_value(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        s = value.strip()
+        if not s:
+            return None
+        try:
+            return float(s)
+        except ValueError:
+            return None
+    return None
+
+
+def parse_run_score_total(run_score: Any) -> Optional[float]:
+    """
+    Best-effort extraction of the rubric total from stored run_score.
+
+    Accepts dict (structured JSON), numeric, or string (including markdown + JSON).
+    """
+    if run_score is None:
+        return None
+    if isinstance(run_score, bool):
+        return None
+    if isinstance(run_score, (int, float)):
+        return float(run_score)
+    if isinstance(run_score, dict):
+        return _coerce_total_value(run_score.get("total"))
+    if not isinstance(run_score, str):
+        return None
+
+    text = run_score.strip()
+    if not text:
+        return None
+
+    for m in _FENCED_JSON_RE.finditer(text):
+        chunk = m.group(1).strip()
+        try:
+            obj = json.loads(chunk)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            v = _coerce_total_value(obj.get("total"))
+            if v is not None:
+                return v
+
+    brace_start = text.rfind("{")
+    if brace_start != -1:
+        tail = text[brace_start:]
+        for end in range(len(tail), 0, -1):
+            snippet = tail[:end]
+            try:
+                obj = json.loads(snippet)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                v = _coerce_total_value(obj.get("total"))
+                if v is not None:
+                    return v
+            break
+
+    m = _TOTAL_IN_JSON_RE.search(text)
+    if m:
+        try:
+            return float(m.group(1))
+        except ValueError:
+            pass
+
+    m = _TOTAL_PROSE_RE.search(text)
+    if m:
+        try:
+            return float(m.group(1))
+        except ValueError:
+            pass
+
+    return None

--- a/backend/apps/microapps/views/analytics_views.py
+++ b/backend/apps/microapps/views/analytics_views.py
@@ -15,6 +15,7 @@ from apps.utils.custom_error_message import ErrorMessages as error
 from apps.utils.usage_helper import MicroAppUsage
 from apps.utils.usage_helper import get_user_ip
 from apps.microapps.models import Microapp, MicroAppUserJoin, Run, AppUsageSession, AppThemeSnapshot
+from apps.microapps.score_utils import parse_run_score_total
 from apps.subscriptions.models import BillingCycle, TopUpToSubscription
 from apps.subscriptions.serializers import BillingDetailsSerializer
 from .mixins import handle_exception
@@ -462,17 +463,29 @@ class AppConversationDetails(APIView):
                 session_id=session_id
             ).values(
                 'timestamp',
+                'user_id',
                 'system_prompt',
                 'phase_instructions',
                 'user_prompt',
                 'response',
+                'credits',
+                'minimum_score',
                 'rubric',
+                'scored_run',
                 'run_score',
                 'run_passed'
             ).order_by('timestamp')
 
+            conversation_list = list(conversation)
+
+            for row in conversation_list:
+                # For scored runs, response typically contains AI score feedback/explanation.
+                row['score_feedback'] = row.get('response') if row.get('scored_run') else ""
+                parsed = parse_run_score_total(row.get('run_score'))
+                row['score_total'] = parsed
+
             return Response(
-                {"data": list(conversation), "status": status.HTTP_200_OK},
+                {"data": conversation_list, "status": status.HTTP_200_OK},
                 status=status.HTTP_200_OK
             )
 

--- a/backend/apps/microapps/views/analytics_views.py
+++ b/backend/apps/microapps/views/analytics_views.py
@@ -466,6 +466,8 @@ class AppConversationDetails(APIView):
                 'user_id',
                 'system_prompt',
                 'phase_instructions',
+                'phase_title',
+                'is_chat_run',
                 'user_prompt',
                 'response',
                 'credits',

--- a/backend/apps/microapps/views/run_views.py
+++ b/backend/apps/microapps/views/run_views.py
@@ -147,6 +147,8 @@ class RunList(APIView, UsageTrackingMixin):
                 "user_ip": ip,
                 "system_prompt": data.get("system_prompt", {}),
                 "phase_instructions": data.get("phase_instructions", {}),
+                "phase_title": str(data.get("phase_title", "") or "")[:255],
+                "is_chat_run": bool(data.get("is_chat_run", False)),
                 "user_prompt": data.get("user_prompt", {}),
                 "app_hash_id": app_hash_id,
                 "response_type": self.response_type,

--- a/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/MicroappStatsContent.tsx
+++ b/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/MicroappStatsContent.tsx
@@ -190,7 +190,7 @@ export default function MicroappStatsContent({
       Timestamp: formatConversationTimestamp(message.timestamp),
       "System Prompt": formatStoredPrompt(message.system_prompt),
       "Phase Instructions": message.phase_instructions,
-      "User Prompt": message.user_prompt,
+      "User Prompt": formatStoredPrompt(message.user_prompt),
       Response: message.response,
       Rubric: message.rubric || "",
       Score: message.score_total ?? parseRunScoreTotal(message.run_score) ?? "",
@@ -236,7 +236,7 @@ export default function MicroappStatsContent({
           ),
           "System Prompt": formatStoredPrompt(message.system_prompt),
           "Phase Instructions": message.phase_instructions,
-          "User Message": message.user_prompt,
+          "User Message": formatStoredPrompt(message.user_prompt),
           "Assistant Response": message.response,
           Rubric: message.rubric || "",
           Score:

--- a/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/MicroappStatsContent.tsx
+++ b/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/MicroappStatsContent.tsx
@@ -17,34 +17,22 @@ import * as XLSX from "xlsx";
 import { format } from "date-fns";
 import { useMicroappAccess } from "@/hooks/useMicroappAccess";
 import { cn } from "@/utils/cn";
+import { parseRunScoreTotal } from "@/utils/parseRunScoreTotal";
+import {
+  type ConversationMessage,
+  formatConversationTimestamp,
+  formatStoredPrompt,
+} from "@/utils/statsConversation";
 import ClockSquareIcon from "@/components/icons/ClockSquareIcon";
 import CoinsSquareIcon from "@/components/icons/CoinsSquareIcon";
 import StaticSquareIcon from "@/components/icons/StatisticSquareIcon";
 import LikeSquareIcon from "@/components/icons/LikeSquareIcon";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "../../edit/[id]/components/ui/dialog";
-import { Card } from "../../edit/[id]/components/ui/card";
-import { Button } from "@/components/Button";
+import { ConversationDetailsDialog } from "./components/ConversationDetailsDialog";
 
 export type MicroappStatsContentProps = {
   hashId: string;
   /** When true, tighter spacing for embedding under FormBuilder chrome */
   embedded?: boolean;
-};
-
-type ConversationMessage = {
-  timestamp: string;
-  system_prompt: string;
-  phase_instructions: string;
-  user_prompt: string;
-  response: string;
-  rubric: string;
-  run_score: number | null;
-  run_passed: boolean | null;
 };
 
 const formatDuration = (seconds: number) => {
@@ -193,9 +181,6 @@ export default function MicroappStatsContent({
     }
   };
 
-  const formatConversationTimestamp = (timestamp: string) =>
-    format(new Date(timestamp), "MMM d, yyyy HH:mm:ss");
-
   const exportConversationToExcel = () => {
     if (!conversationDetail?.data || !selectedSessionId) {
       return;
@@ -203,12 +188,12 @@ export default function MicroappStatsContent({
 
     const exportData = conversationDetail.data.map((message) => ({
       Timestamp: formatConversationTimestamp(message.timestamp),
-      "System Prompt": message.system_prompt,
+      "System Prompt": formatStoredPrompt(message.system_prompt),
       "Phase Instructions": message.phase_instructions,
       "User Prompt": message.user_prompt,
       Response: message.response,
       Rubric: message.rubric || "",
-      Score: message.run_score ?? "",
+      Score: message.score_total ?? parseRunScoreTotal(message.run_score) ?? "",
       Passed:
         message.run_passed === null ? "" : message.run_passed ? "Yes" : "No",
     }));
@@ -249,12 +234,13 @@ export default function MicroappStatsContent({
             new Date(message.timestamp),
             "yyyy-MM-dd HH:mm:ss"
           ),
-          "System Prompt": message.system_prompt,
+          "System Prompt": formatStoredPrompt(message.system_prompt),
           "Phase Instructions": message.phase_instructions,
           "User Message": message.user_prompt,
           "Assistant Response": message.response,
           Rubric: message.rubric || "",
-          Score: message.run_score || "",
+          Score:
+            message.score_total ?? parseRunScoreTotal(message.run_score) ?? "",
           Passed:
             message.run_passed === null
               ? ""
@@ -347,6 +333,9 @@ export default function MicroappStatsContent({
     "PASS/FAILS",
     "",
   ];
+  const selectedConversation = conversations.find(
+    (conv) => String(conv.session_id ?? "") === selectedSessionId
+  );
 
   return (
     <div className="bg-secondary-grey-100 h-full">
@@ -528,101 +517,14 @@ export default function MicroappStatsContent({
           </div>
         </div>
 
-        <Dialog
+        <ConversationDetailsDialog
           open={conversationDialogOpen}
           onOpenChange={onConversationDialogOpenChange}
-        >
-          <DialogContent className="max-w-4xl max-h-[90vh] flex flex-col gap-0 overflow-hidden p-0 sm:rounded-lg">
-            <DialogHeader className="shrink-0 border-b px-6 py-4 pr-12 text-left">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-                <DialogTitle className="text-lg font-semibold">
-                  Conversation
-                  {selectedSessionId ? (
-                    <span className="mt-1 block font-mono text-xs font-normal text-muted-foreground">
-                      {selectedSessionId}
-                    </span>
-                  ) : null}
-                </DialogTitle>
-                <Button
-                  type="button"
-                  onClick={exportConversationToExcel}
-                  disabled={
-                    !conversationDetail?.data?.length ||
-                    conversationDetailLoading
-                  }
-                  className="shrink-0 bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg flex items-center gap-2 w-fit"
-                >
-                  <Download className="h-4 w-4" />
-                  Export to Excel
-                </Button>
-              </div>
-            </DialogHeader>
-            <div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
-              {conversationDetailLoading ? (
-                <div className="flex justify-center py-12">
-                  <SkeletonLoader />
-                </div>
-              ) : conversationDetail?.data?.length ? (
-                <div className="space-y-4">
-                  {conversationDetail.data.map(
-                    (message: ConversationMessage, index: number) => (
-                      <Card key={index} className="p-4 sm:p-6">
-                        <div className="text-sm text-gray-500 mb-4">
-                          {formatConversationTimestamp(message.timestamp)}
-                        </div>
-
-                        {message.phase_instructions ? (
-                          <div className="mb-4 p-3 bg-gray-50 rounded-lg">
-                            <div className="text-sm font-medium text-gray-700">
-                              Phase Instructions:
-                            </div>
-                            <div className="text-gray-600">
-                              {message.phase_instructions}
-                            </div>
-                          </div>
-                        ) : null}
-
-                        <div className="flex flex-col space-y-4">
-                          <div className="flex items-start">
-                            <div className="flex-shrink-0 w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center">
-                              <span className="text-blue-600">U</span>
-                            </div>
-                            <div className="ml-3 bg-blue-50 rounded-lg p-3 flex-grow min-w-0">
-                              <div className="text-sm font-medium text-gray-900">
-                                User
-                              </div>
-                              <div className="text-gray-700 break-words">
-                                {message.user_prompt}
-                              </div>
-                            </div>
-                          </div>
-
-                          <div className="flex items-start">
-                            <div className="flex-shrink-0 w-10 h-10 rounded-full bg-green-100 flex items-center justify-center">
-                              <span className="text-green-600">A</span>
-                            </div>
-                            <div className="ml-3 bg-green-50 rounded-lg p-3 flex-grow min-w-0">
-                              <div className="text-sm font-medium text-gray-900">
-                                Assistant
-                              </div>
-                              <div className="text-gray-700 whitespace-pre-wrap break-words">
-                                {message.response}
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </Card>
-                    )
-                  )}
-                </div>
-              ) : (
-                <p className="text-center text-sm text-muted-foreground py-12">
-                  No messages in this conversation.
-                </p>
-              )}
-            </div>
-          </DialogContent>
-        </Dialog>
+          loading={conversationDetailLoading}
+          detail={conversationDetail}
+          selectedConversation={selectedConversation ?? null}
+          onExportExcel={exportConversationToExcel}
+        />
 
         <DebugInformation
           surveyJson={null}

--- a/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ChatInstructionsCollapsible.tsx
+++ b/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ChatInstructionsCollapsible.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { cn } from "@/utils/cn";
+import { CHAT_INSTRUCTIONS_COLLAPSE_CHARS } from "@/utils/statsConversation";
+
+export type ChatInstructionsCollapsibleProps = {
+  text: string;
+};
+
+export function ChatInstructionsCollapsible({
+  text,
+}: ChatInstructionsCollapsibleProps) {
+  const [expanded, setExpanded] = useState(false);
+  const long = text.length > CHAT_INSTRUCTIONS_COLLAPSE_CHARS;
+
+  return (
+    <div className="flex w-full flex-col gap-2.5 border border-[#d7d9dd] p-3">
+      <div className="text-sm font-semibold leading-[18px]">
+        Chat Instructions:
+      </div>
+      <p
+        className={cn(
+          "text-sm leading-[18px] text-[#21262d] whitespace-pre-wrap break-words",
+          !expanded && long && "line-clamp-4"
+        )}
+      >
+        {text}
+      </p>
+      {long ? (
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 text-sm text-primary"
+          onClick={() => setExpanded((e) => !e)}
+        >
+          {expanded ? (
+            <>
+              <ChevronUp className="h-4 w-4 shrink-0" />
+              Show less
+            </>
+          ) : (
+            <>
+              <ChevronDown className="h-4 w-4 shrink-0" />
+              Show more
+            </>
+          )}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ChatInstructionsCollapsible.tsx
+++ b/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ChatInstructionsCollapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { cn } from "@/utils/cn";
 import { CHAT_INSTRUCTIONS_COLLAPSE_CHARS } from "@/utils/statsConversation";
@@ -14,20 +14,43 @@ export function ChatInstructionsCollapsible({
 }: ChatInstructionsCollapsibleProps) {
   const [expanded, setExpanded] = useState(false);
   const long = text.length > CHAT_INSTRUCTIONS_COLLAPSE_CHARS;
+  const contentRef = useRef<HTMLParagraphElement | null>(null);
+  const [expandedHeight, setExpandedHeight] = useState<number>(0);
+  const collapsedHeight = 72; // 4 lines * 18px line-height
+
+  useEffect(() => {
+    if (!long) return;
+    const el = contentRef.current;
+    if (!el) return;
+    setExpandedHeight(el.scrollHeight);
+  }, [text, expanded, long]);
 
   return (
     <div className="flex w-full flex-col gap-2.5 border border-[#d7d9dd] p-3">
       <div className="text-sm font-semibold leading-[18px]">
         Chat Instructions:
       </div>
-      <p
-        className={cn(
-          "text-sm leading-[18px] text-[#21262d] whitespace-pre-wrap break-words",
-          !expanded && long && "line-clamp-4"
-        )}
+      <div
+        className="overflow-hidden transition-[max-height,opacity] duration-300 ease-out"
+        style={{
+          maxHeight: long
+            ? expanded
+              ? `${Math.max(expandedHeight, collapsedHeight)}px`
+              : `${collapsedHeight}px`
+            : undefined,
+          opacity: expanded || !long ? 1 : 0.96,
+        }}
       >
-        {text}
-      </p>
+        <p
+          ref={contentRef}
+          className={cn(
+            "text-sm leading-[18px] text-[#21262d] whitespace-pre-wrap break-words",
+            !expanded && long && "line-clamp-4"
+          )}
+        >
+          {text}
+        </p>
+      </div>
       {long ? (
         <button
           type="button"

--- a/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ChatPhaseCard.tsx
+++ b/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ChatPhaseCard.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { ConversationMessage } from "@/utils/statsConversation";
+import { formatStoredPrompt } from "@/utils/statsConversation";
+import { ChatInstructionsCollapsible } from "./ChatInstructionsCollapsible";
+import { ConversationTurnBlock } from "./ConversationTurnBlock";
+
+export type ChatPhaseCardProps = {
+  phaseTitle: string;
+  instructionsSource: unknown;
+  messages: ConversationMessage[];
+  formatTimestamp: (ts: string) => string;
+  totalCreditsFallback: number;
+};
+
+/**
+ * Figma: phase title + bordered Chat Instructions + stacked chat turns (40px between turns).
+ */
+export function ChatPhaseCard({
+  phaseTitle,
+  instructionsSource,
+  messages,
+  formatTimestamp,
+  totalCreditsFallback,
+}: ChatPhaseCardProps) {
+  const instructionsText = formatStoredPrompt(instructionsSource).trim();
+  const heading = phaseTitle.trim() || "Chat";
+
+  return (
+    <div className="flex flex-col gap-4 bg-white p-4 sm:p-5">
+      <h4 className="text-base font-semibold leading-5">{heading}</h4>
+      <div className="flex flex-col gap-5">
+        {instructionsText ? (
+          <ChatInstructionsCollapsible text={instructionsText} />
+        ) : null}
+        <div className="flex flex-col gap-10">
+          {messages.map((message, index) => (
+            <ConversationTurnBlock
+              key={`${message.timestamp}-${index}`}
+              message={message}
+              formatTimestamp={formatTimestamp}
+              totalCreditsFallback={totalCreditsFallback}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ConversationBubble.tsx
+++ b/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ConversationBubble.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { cn } from "@/utils/cn";
+
+export type ConversationBubbleProps = {
+  role: "user" | "assistant";
+  text: string;
+};
+
+export function ConversationBubble({ role, text }: ConversationBubbleProps) {
+  const isUser = role === "user";
+  return (
+    <div className="flex w-full items-end gap-3">
+      <div
+        className={cn(
+          "flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-base leading-5 text-gray-600",
+          isUser ? "bg-[#f5f6f9]" : "bg-[rgba(225,227,255,0.5)]"
+        )}
+      >
+        {isUser ? "U" : "A"}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div
+          className={cn(
+            "w-full p-3",
+            isUser ? "bg-[#f5f6f9]" : "bg-[rgba(225,227,255,0.5)]"
+          )}
+        >
+          <div className="text-sm font-semibold leading-[18px]">
+            {isUser ? "User" : "Assistant"}
+          </div>
+          <div className="mt-2 text-sm leading-[18px] whitespace-pre-wrap break-words">
+            {text || "-"}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ConversationDetailsDialog.tsx
+++ b/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ConversationDetailsDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ChevronDown, ChevronUp, Download } from "lucide-react";
 import SkeletonLoader from "@/components/layout/loading/skeletonLoader";
 import { Button } from "@/components/Button";
@@ -52,6 +52,11 @@ export function ConversationDetailsDialog({
   onExportExcel,
 }: ConversationDetailsDialogProps) {
   const [systemPromptExpanded, setSystemPromptExpanded] = useState(false);
+  const systemPromptRef = useRef<HTMLParagraphElement | null>(null);
+  const [systemPromptExpandedHeight, setSystemPromptExpandedHeight] =
+    useState<number>(0);
+
+  const sessionSystemPromptText = getSessionSystemPromptText(detail?.data);
 
   useEffect(() => {
     if (!open) {
@@ -59,7 +64,12 @@ export function ConversationDetailsDialog({
     }
   }, [open]);
 
-  const sessionSystemPromptText = getSessionSystemPromptText(detail?.data);
+  useEffect(() => {
+    const el = systemPromptRef.current;
+    if (!el || !sessionSystemPromptText) return;
+    setSystemPromptExpandedHeight(el.scrollHeight);
+  }, [sessionSystemPromptText, systemPromptExpanded]);
+
   const phaseGroups = detail?.data?.length
     ? groupConversationMessagesByPhase(detail.data)
     : [];
@@ -137,17 +147,37 @@ export function ConversationDetailsDialog({
                   <h4 className="text-base leading-5 font-semibold">
                     System prompt
                   </h4>
-                  <p
-                    className={cn(
-                      "mt-4 text-sm leading-[18px] text-gray-600 whitespace-pre-wrap break-words",
-                      !systemPromptExpanded &&
+                  <div
+                    className="mt-4 overflow-hidden transition-[max-height,opacity] duration-300 ease-out"
+                    style={{
+                      maxHeight:
                         sessionSystemPromptText.length >
-                          SYSTEM_PROMPT_COLLAPSE_CHARS &&
-                        "line-clamp-6"
-                    )}
+                        SYSTEM_PROMPT_COLLAPSE_CHARS
+                          ? systemPromptExpanded
+                            ? `${Math.max(systemPromptExpandedHeight, 108)}px`
+                            : "108px"
+                          : undefined,
+                      opacity:
+                        systemPromptExpanded ||
+                        sessionSystemPromptText.length <=
+                          SYSTEM_PROMPT_COLLAPSE_CHARS
+                          ? 1
+                          : 0.96,
+                    }}
                   >
-                    {sessionSystemPromptText}
-                  </p>
+                    <p
+                      ref={systemPromptRef}
+                      className={cn(
+                        "text-sm leading-[18px] text-gray-600 whitespace-pre-wrap break-words",
+                        !systemPromptExpanded &&
+                          sessionSystemPromptText.length >
+                            SYSTEM_PROMPT_COLLAPSE_CHARS &&
+                          "line-clamp-6"
+                      )}
+                    >
+                      {sessionSystemPromptText}
+                    </p>
+                  </div>
                   {sessionSystemPromptText.length >
                   SYSTEM_PROMPT_COLLAPSE_CHARS ? (
                     <button

--- a/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ConversationDetailsDialog.tsx
+++ b/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ConversationDetailsDialog.tsx
@@ -5,21 +5,25 @@ import { ChevronDown, ChevronUp, Download } from "lucide-react";
 import SkeletonLoader from "@/components/layout/loading/skeletonLoader";
 import { Button } from "@/components/Button";
 import { cn } from "@/utils/cn";
-import { formatScoreGateTotal } from "@/utils/parseRunScoreTotal";
 import {
   ConversationMessage,
   SYSTEM_PROMPT_COLLAPSE_CHARS,
   formatConversationHeaderTimestamp,
   formatConversationTimestamp,
   getSessionSystemPromptText,
+  groupConversationMessagesByPhase,
 } from "@/utils/statsConversation";
-import { ConversationBubble } from "./ConversationBubble";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "../../../edit/[id]/components/ui/dialog";
+import { ChatPhaseCard } from "./ChatPhaseCard";
+import {
+  ConversationTurnBlock,
+  isConversationScoreOnly,
+} from "./ConversationTurnBlock";
 
 export type SelectedConversationRow = {
   session_id?: string | number;
@@ -56,21 +60,11 @@ export function ConversationDetailsDialog({
   }, [open]);
 
   const sessionSystemPromptText = getSessionSystemPromptText(detail?.data);
+  const phaseGroups = detail?.data?.length
+    ? groupConversationMessagesByPhase(detail.data)
+    : [];
 
-  const showScoreGate = (message: ConversationMessage) => {
-    return (
-      message.scored_run &&
-      message.run_score &&
-      typeof message.score_feedback === "string" &&
-      message.score_feedback.trim() !== ""
-    );
-  };
-
-  const showUserPrompt = (message: ConversationMessage) => {
-    if (showScoreGate(message) && message.user_prompt === ".") return false;
-
-    return message.user_prompt;
-  };
+  const creditsFallback = Number(selectedConversation?.total_credits || 0);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -176,89 +170,50 @@ export function ConversationDetailsDialog({
                   ) : null}
                 </div>
               ) : null}
-              {detail.data.map((message, index) => (
-                <>
-                  {!(showScoreGate(message) && !showUserPrompt(message)) && (
-                    <div key={index} className="bg-white p-4">
-                      <div className="space-y-4">
-                        {showUserPrompt(message) && (
-                          <ConversationBubble
-                            role="user"
-                            text={message.user_prompt}
-                          />
-                        )}
-                        {!showScoreGate(message) ? (
-                          <ConversationBubble
-                            role="assistant"
-                            text={message.response}
-                          />
-                        ) : (
-                          <></>
-                        )}
-                      </div>
-                      <div className="mt-5 flex items-center justify-between text-sm text-gray-600">
-                        <span>
-                          {formatConversationTimestamp(message.timestamp)}
-                        </span>
-                        <span>
-                          Credits:{" "}
-                          {Number.isFinite(Number(message.credits))
-                            ? Number(message.credits).toLocaleString()
-                            : Number(selectedConversation?.total_credits || 0)}
-                        </span>
-                      </div>
-                    </div>
-                  )}
 
-                  {showScoreGate(message) ? (
-                    <div className="mt-4 border border-primary bg-[rgba(225,227,255,0.5)] p-4">
-                      <h4 className="text-base font-semibold leading-5">
-                        Score Gate
-                      </h4>
-                      <div className="mt-4 flex flex-wrap gap-10 text-sm">
-                        <div>
-                          <p className="text-gray-600">Score</p>
-                          <p className="mt-2 font-medium">
-                            {formatScoreGateTotal(
-                              message.score_total,
-                              message.run_score
-                            )}
-                          </p>
-                        </div>
-                        <div>
-                          <p className="text-gray-600">Minimum score</p>
-                          <p className="mt-2 font-medium">
-                            {message.minimum_score ?? "-"}
-                          </p>
-                        </div>
-                        <div>
-                          <p className="text-gray-600">Run passed</p>
-                          <p
-                            className={cn(
-                              "mt-2 font-medium",
-                              message.run_passed === true
-                                ? "text-[#249953]"
-                                : "text-[#df3f46]"
-                            )}
-                          >
-                            {message.run_passed === null
-                              ? "-"
-                              : message.run_passed
-                              ? "Yes"
-                              : "No"}
-                          </p>
-                        </div>
-                      </div>
+              {phaseGroups.map((group, gi) => {
+                const useChatPhaseLayout = group.messages.some(
+                  (m) => m.is_chat_run
+                );
 
-                      {message.score_feedback ? (
-                        <div className="mt-4 bg-white p-3 text-sm leading-[18px] text-gray-600 whitespace-pre-wrap break-words">
-                          {message.score_feedback}
-                        </div>
-                      ) : null}
+                if (useChatPhaseLayout) {
+                  return (
+                    <ChatPhaseCard
+                      key={`phase-${gi}-${group.mergeKey}`}
+                      phaseTitle={group.phaseTitle}
+                      instructionsSource={group.messages[0]?.phase_instructions}
+                      messages={group.messages}
+                      formatTimestamp={formatConversationTimestamp}
+                      totalCreditsFallback={creditsFallback}
+                    />
+                  );
+                }
+
+                const message = group.messages[0];
+                const scoreOnly = isConversationScoreOnly(message);
+
+                if (scoreOnly) {
+                  return (
+                    <div key={`row-${gi}`} className="mt-0">
+                      <ConversationTurnBlock
+                        message={message}
+                        formatTimestamp={formatConversationTimestamp}
+                        totalCreditsFallback={creditsFallback}
+                      />
                     </div>
-                  ) : null}
-                </>
-              ))}
+                  );
+                }
+
+                return (
+                  <div key={`row-${gi}`} className="bg-white p-4">
+                    <ConversationTurnBlock
+                      message={message}
+                      formatTimestamp={formatConversationTimestamp}
+                      totalCreditsFallback={creditsFallback}
+                    />
+                  </div>
+                );
+              })}
             </div>
           ) : (
             <p className="text-center text-sm text-muted-foreground py-12">

--- a/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ConversationDetailsDialog.tsx
+++ b/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ConversationDetailsDialog.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ChevronDown, ChevronUp, Download } from "lucide-react";
+import SkeletonLoader from "@/components/layout/loading/skeletonLoader";
+import { Button } from "@/components/Button";
+import { cn } from "@/utils/cn";
+import { formatScoreGateTotal } from "@/utils/parseRunScoreTotal";
+import {
+  ConversationMessage,
+  SYSTEM_PROMPT_COLLAPSE_CHARS,
+  formatConversationHeaderTimestamp,
+  formatConversationTimestamp,
+  getSessionSystemPromptText,
+} from "@/utils/statsConversation";
+import { ConversationBubble } from "./ConversationBubble";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "../../../edit/[id]/components/ui/dialog";
+
+export type SelectedConversationRow = {
+  session_id?: string | number;
+  start_time?: string;
+  model?: string;
+  passes?: number;
+  fails?: number;
+  total_credits?: number;
+} | null;
+
+export type ConversationDetailsDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  loading: boolean;
+  detail: { data: ConversationMessage[] } | null;
+  selectedConversation: SelectedConversationRow;
+  onExportExcel: () => void;
+};
+
+export function ConversationDetailsDialog({
+  open,
+  onOpenChange,
+  loading,
+  detail,
+  selectedConversation,
+  onExportExcel,
+}: ConversationDetailsDialogProps) {
+  const [systemPromptExpanded, setSystemPromptExpanded] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setSystemPromptExpanded(false);
+    }
+  }, [open]);
+
+  const sessionSystemPromptText = getSessionSystemPromptText(detail?.data);
+
+  const showScoreGate = (message: ConversationMessage) => {
+    return (
+      message.scored_run &&
+      message.run_score &&
+      typeof message.score_feedback === "string" &&
+      message.score_feedback.trim() !== ""
+    );
+  };
+
+  const showUserPrompt = (message: ConversationMessage) => {
+    if (showScoreGate(message) && message.user_prompt === ".") return false;
+
+    return message.user_prompt;
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        overlayStyle={{ backgroundColor: "rgba(0, 0, 0, 0.5)" }}
+        className="max-w-5xl max-h-[90vh] flex flex-col gap-0 overflow-hidden p-0 sm:rounded-lg"
+      >
+        <div className="min-h-0 flex-1 overflow-y-auto bg-secondary-grey-100">
+          {loading ? (
+            <div className="flex justify-center py-12">
+              <SkeletonLoader />
+            </div>
+          ) : detail?.data?.length ? (
+            <div className="space-y-5 p-5">
+              <div className="bg-white p-5">
+                <DialogHeader className="pb-5 pr-12 text-left border-b">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <DialogTitle className="text-2xl leading-8 font-semibold">
+                        Conversation details
+                      </DialogTitle>
+                      <div className="mt-2 text-sm text-gray-600">
+                        {selectedConversation?.start_time
+                          ? formatConversationHeaderTimestamp(
+                              selectedConversation.start_time
+                            )
+                          : "-"}
+                      </div>
+                    </div>
+                    <Button
+                      type="button"
+                      onClick={onExportExcel}
+                      disabled={!detail?.data?.length || loading}
+                      className="shrink-0 bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg flex items-center gap-2"
+                    >
+                      <Download className="h-4 w-4" />
+                      Export to Excel
+                    </Button>
+                  </div>
+                </DialogHeader>
+                <div className="mt-5 flex flex-wrap gap-8 text-sm">
+                  <div className="space-y-2">
+                    <p className="text-gray-600">Model</p>
+                    <span className="inline-flex items-center rounded bg-secondary-grey-100 px-2.5 py-0.5 text-xs text-gray-600">
+                      {selectedConversation?.model || "-"}
+                    </span>
+                  </div>
+                  <div className="space-y-2">
+                    <p className="text-gray-600">User ID</p>
+                    <p className="font-medium text-[#0f1114]">
+                      {detail.data[0]?.user_id ?? "-"}
+                    </p>
+                  </div>
+                  <div className="space-y-2">
+                    <p className="text-gray-600">Pass/Fail</p>
+                    <p>
+                      <span className="text-[#249953]">
+                        {Number(selectedConversation?.passes || 0)} passes
+                      </span>{" "}
+                      /{" "}
+                      <span className="text-[#df3f46]">
+                        {Number(selectedConversation?.fails || 0)} fails
+                      </span>
+                    </p>
+                  </div>
+                </div>
+              </div>
+              {sessionSystemPromptText ? (
+                <div className="bg-white p-4 sm:p-5">
+                  <h4 className="text-base leading-5 font-semibold">
+                    System prompt
+                  </h4>
+                  <p
+                    className={cn(
+                      "mt-4 text-sm leading-[18px] text-gray-600 whitespace-pre-wrap break-words",
+                      !systemPromptExpanded &&
+                        sessionSystemPromptText.length >
+                          SYSTEM_PROMPT_COLLAPSE_CHARS &&
+                        "line-clamp-6"
+                    )}
+                  >
+                    {sessionSystemPromptText}
+                  </p>
+                  {sessionSystemPromptText.length >
+                  SYSTEM_PROMPT_COLLAPSE_CHARS ? (
+                    <button
+                      type="button"
+                      className="mt-3 inline-flex items-center gap-1 text-sm text-primary"
+                      onClick={() => setSystemPromptExpanded((e) => !e)}
+                    >
+                      {systemPromptExpanded ? (
+                        <>
+                          <ChevronUp className="h-4 w-4" />
+                          Show less
+                        </>
+                      ) : (
+                        <>
+                          <ChevronDown className="h-4 w-4" />
+                          Show more
+                        </>
+                      )}
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
+              {detail.data.map((message, index) => (
+                <>
+                  {!(showScoreGate(message) && !showUserPrompt(message)) && (
+                    <div key={index} className="bg-white p-4">
+                      <div className="space-y-4">
+                        {showUserPrompt(message) && (
+                          <ConversationBubble
+                            role="user"
+                            text={message.user_prompt}
+                          />
+                        )}
+                        {!showScoreGate(message) ? (
+                          <ConversationBubble
+                            role="assistant"
+                            text={message.response}
+                          />
+                        ) : (
+                          <></>
+                        )}
+                      </div>
+                      <div className="mt-5 flex items-center justify-between text-sm text-gray-600">
+                        <span>
+                          {formatConversationTimestamp(message.timestamp)}
+                        </span>
+                        <span>
+                          Credits:{" "}
+                          {Number.isFinite(Number(message.credits))
+                            ? Number(message.credits).toLocaleString()
+                            : Number(selectedConversation?.total_credits || 0)}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+
+                  {showScoreGate(message) ? (
+                    <div className="mt-4 border border-primary bg-[rgba(225,227,255,0.5)] p-4">
+                      <h4 className="text-base font-semibold leading-5">
+                        Score Gate
+                      </h4>
+                      <div className="mt-4 flex flex-wrap gap-10 text-sm">
+                        <div>
+                          <p className="text-gray-600">Score</p>
+                          <p className="mt-2 font-medium">
+                            {formatScoreGateTotal(
+                              message.score_total,
+                              message.run_score
+                            )}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-gray-600">Minimum score</p>
+                          <p className="mt-2 font-medium">
+                            {message.minimum_score ?? "-"}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-gray-600">Run passed</p>
+                          <p
+                            className={cn(
+                              "mt-2 font-medium",
+                              message.run_passed === true
+                                ? "text-[#249953]"
+                                : "text-[#df3f46]"
+                            )}
+                          >
+                            {message.run_passed === null
+                              ? "-"
+                              : message.run_passed
+                              ? "Yes"
+                              : "No"}
+                          </p>
+                        </div>
+                      </div>
+
+                      {message.score_feedback ? (
+                        <div className="mt-4 bg-white p-3 text-sm leading-[18px] text-gray-600 whitespace-pre-wrap break-words">
+                          {message.score_feedback}
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </>
+              ))}
+            </div>
+          ) : (
+            <p className="text-center text-sm text-muted-foreground py-12">
+              No messages in this conversation.
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ConversationTurnBlock.tsx
+++ b/frontend/src/app/(authenticated)/app/(pages)/[id]/stats/components/ConversationTurnBlock.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { cn } from "@/utils/cn";
+import { formatScoreGateTotal } from "@/utils/parseRunScoreTotal";
+import type { ConversationMessage } from "@/utils/statsConversation";
+import { formatStoredPrompt } from "@/utils/statsConversation";
+import { ConversationBubble } from "./ConversationBubble";
+
+export type ConversationTurnBlockProps = {
+  message: ConversationMessage;
+  formatTimestamp: (ts: string) => string;
+  totalCreditsFallback: number;
+};
+
+function showScoreGate(message: ConversationMessage) {
+  return (
+    Boolean(message.scored_run) &&
+    Boolean(message.run_score) &&
+    typeof message.score_feedback === "string" &&
+    message.score_feedback.trim() !== ""
+  );
+}
+
+function userPromptRaw(message: ConversationMessage): string {
+  const u = message.user_prompt as unknown;
+  if (typeof u === "string") return u;
+  return formatStoredPrompt(u);
+}
+
+function showUserPrompt(message: ConversationMessage) {
+  const raw = userPromptRaw(message);
+  if (showScoreGate(message) && raw === ".") return false;
+  return Boolean(raw?.trim());
+}
+
+/** Run row that only renders score gate (dummy "." user turn). */
+export function isConversationScoreOnly(message: ConversationMessage): boolean {
+  return showScoreGate(message) && !showUserPrompt(message);
+}
+
+function ScoreGateSection({ message }: { message: ConversationMessage }) {
+  return (
+    <div className="border border-primary bg-[rgba(225,227,255,0.5)] p-4">
+      <h4 className="text-base font-semibold leading-5">Score Gate</h4>
+      <div className="mt-4 flex flex-wrap gap-10 text-sm">
+        <div>
+          <p className="text-[#4b5563]">Score</p>
+          <p className="mt-2 font-medium">
+            {formatScoreGateTotal(message.score_total, message.run_score)}
+          </p>
+        </div>
+        <div>
+          <p className="text-[#4b5563]">Minimum score</p>
+          <p className="mt-2 font-medium">{message.minimum_score ?? "-"}</p>
+        </div>
+        <div>
+          <p className="text-[#4b5563]">Run passed</p>
+          <p
+            className={cn(
+              "mt-2 font-medium",
+              message.run_passed === true ? "text-[#249953]" : "text-[#df3f46]"
+            )}
+          >
+            {message.run_passed === null
+              ? "-"
+              : message.run_passed
+              ? "Yes"
+              : "No"}
+          </p>
+        </div>
+      </div>
+      {message.score_feedback ? (
+        <div className="mt-4 bg-white p-3 text-sm leading-[18px] text-gray-600 whitespace-pre-wrap break-words">
+          {message.score_feedback}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/** One user/assistant pair, timestamp row, and optional score gate (matches chatbot + Figma). */
+export function ConversationTurnBlock({
+  message,
+  formatTimestamp,
+  totalCreditsFallback,
+}: ConversationTurnBlockProps) {
+  const gate = showScoreGate(message);
+  const user = showUserPrompt(message);
+
+  if (gate && !user) {
+    return <ScoreGateSection message={message} />;
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="space-y-4">
+        {showUserPrompt(message) ? (
+          <ConversationBubble role="user" text={userPromptRaw(message)} />
+        ) : null}
+        {!gate ? (
+          <ConversationBubble role="assistant" text={message.response} />
+        ) : null}
+      </div>
+      <div className="flex items-center justify-between text-sm leading-[18px] text-gray-600">
+        <span>{formatTimestamp(message.timestamp)}</span>
+        <span>
+          Credits:{" "}
+          {Number.isFinite(Number(message.credits))
+            ? Number(message.credits).toLocaleString()
+            : totalCreditsFallback}
+        </span>
+      </div>
+      {gate ? <ScoreGateSection message={message} /> : null}
+    </div>
+  );
+}

--- a/frontend/src/app/(authenticated)/app/(pages)/edit/[id]/components/ui/dialog.tsx
+++ b/frontend/src/app/(authenticated)/app/(pages)/edit/[id]/components/ui/dialog.tsx
@@ -1,10 +1,10 @@
-'use client';
+"use client";
 
-import * as React from 'react';
-import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { X } from 'lucide-react';
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
 
-import { cn } from '../../lib/utils';
+import { cn } from "../../lib/utils";
 
 const Dialog = DialogPrimitive.Root;
 
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -31,14 +31,17 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    overlayClassName?: string;
+    overlayStyle?: React.CSSProperties;
+  }
+>(({ className, children, overlayClassName, overlayStyle, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay />
+    <DialogOverlay className={overlayClassName} style={overlayStyle} />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}
@@ -59,13 +62,13 @@ const DialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      'flex flex-col space-y-1.5 text-center sm:text-left',
+      "flex flex-col space-y-1.5 text-center sm:text-left",
       className
     )}
     {...props}
   />
 );
-DialogHeader.displayName = 'DialogHeader';
+DialogHeader.displayName = "DialogHeader";
 
 const DialogFooter = ({
   className,
@@ -73,13 +76,13 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
       className
     )}
     {...props}
   />
 );
-DialogFooter.displayName = 'DialogFooter';
+DialogFooter.displayName = "DialogFooter";
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
@@ -88,7 +91,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      'text-lg font-semibold leading-none tracking-tight',
+      "text-lg font-semibold leading-none tracking-tight",
       className
     )}
     {...props}
@@ -102,7 +105,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
+    className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
 ));

--- a/frontend/src/components/QuestionTypes/ChatQuestion.tsx
+++ b/frontend/src/components/QuestionTypes/ChatQuestion.tsx
@@ -319,6 +319,7 @@ const ChatQuestion: React.FC<ChatQuestionProps> = ({
         userId: userId,
         requestSkip: false,
         skipScoredRun: true,
+        runSource: "chat",
         transcriptionCost: transcriptionCost,
         defaultAiModel: defaultAiModel,
         set: (state: any) => {

--- a/frontend/src/utils/buildRequestBody.ts
+++ b/frontend/src/utils/buildRequestBody.ts
@@ -62,6 +62,8 @@ export const buildRequestBody = async (
   scoreExplanation?: boolean,
   scoreExplanationMode?: "always" | "failed_only" | "passed_only" | "never",
   activeTryId?: string,
+  phaseTitle?: string,
+  runSource?: "default" | "chat",
 ) => {
   const store = useConversationStore.getState();
   const scopedRuns = store.getRunsForTry(activeTryId);
@@ -214,6 +216,9 @@ export const buildRequestBody = async (
 
   const conversationId = store.ensureConversation();
   requestBody.session_id = conversationId;
+
+  requestBody.phase_title = (phaseTitle ?? "").slice(0, 255);
+  requestBody.is_chat_run = runSource === "chat";
 
   return requestBody;
 };

--- a/frontend/src/utils/parseRunScoreTotal.ts
+++ b/frontend/src/utils/parseRunScoreTotal.ts
@@ -1,0 +1,63 @@
+/**
+ * Extract rubric total from Run.run_score (API may return raw LLM prose + fenced JSON).
+ */
+
+function coerceTotal(value: unknown): number | null {
+  if (value == null) return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = parseFloat(value.trim());
+    return Number.isNaN(n) ? null : n;
+  }
+  return null;
+}
+
+export function parseRunScoreTotal(runScore: unknown): number | null {
+  if (runScore == null) return null;
+  if (typeof runScore === "number" && Number.isFinite(runScore)) return runScore;
+  if (typeof runScore === "string") {
+    const text = runScore.trim();
+    if (!text) return null;
+    const fenceRe = /```(?:json)?\s*([\s\S]*?)\s*```/gi;
+    let m: RegExpExecArray | null;
+    while ((m = fenceRe.exec(text)) !== null) {
+      try {
+        const obj = JSON.parse(m[1].trim()) as unknown;
+        if (obj && typeof obj === "object" && "total" in obj) {
+          const v = coerceTotal((obj as { total: unknown }).total);
+          if (v !== null) return v;
+        }
+      } catch {
+        /* next fence */
+      }
+    }
+    const jsonTotal = text.match(/"total"\s*:\s*"?([\d.]+)"?/i);
+    if (jsonTotal) {
+      const v = parseFloat(jsonTotal[1]);
+      if (!Number.isNaN(v)) return v;
+    }
+    const proseTotal = text.match(/\btotal\s*:\s*([\d.]+)\b/i);
+    if (proseTotal) {
+      const v = parseFloat(proseTotal[1]);
+      if (!Number.isNaN(v)) return v;
+    }
+    return null;
+  }
+  if (typeof runScore === "object" && runScore !== null && "total" in runScore) {
+    return coerceTotal((runScore as { total: unknown }).total);
+  }
+  return null;
+}
+
+export function formatScoreGateTotal(
+  scoreTotal: number | null | undefined,
+  runScore: unknown
+): string {
+  const n =
+    typeof scoreTotal === "number" && Number.isFinite(scoreTotal)
+      ? scoreTotal
+      : parseRunScoreTotal(runScore);
+  if (n === null) return "-";
+  if (Number.isInteger(n)) return String(Math.trunc(n));
+  return String(n);
+}

--- a/frontend/src/utils/sendPrompts.ts
+++ b/frontend/src/utils/sendPrompts.ts
@@ -411,6 +411,7 @@ export const sendPromptsUtil = async (options: {
   scoreExplanation?: boolean;
   scoreExplanationMode?: "always" | "failed_only" | "passed_only" | "never";
   defaultAiModel?: string;
+  runSource?: "default" | "chat";
   runtimeMeta?: {
     tryId?: string;
     tryIndex?: number;
@@ -432,6 +433,7 @@ const {
     transcriptionCost,
     scoreExplanation,
     scoreExplanationMode,
+    runSource = "default",
     runtimeMeta
   } = options;
 
@@ -471,6 +473,7 @@ const {
     const attachedFiles = appConfig?.attachedFiles || [];
    const page = appConfig?.phases?.[pageIndex] || null;
    const pageConfig = pageConfigOverride ?? getPageConfig(page);
+   const phaseTitle = page?.title ?? "";
 
    //Create a run with current settings and 'pending' status
    //Creating a run will automatically add it to the conversation, if it exists. Or, it will create a new one if it doesn't.
@@ -542,7 +545,9 @@ const {
       run.id,
       scoreExplanation,
       scoreExplanationMode,
-      runtimeMeta?.tryId
+      runtimeMeta?.tryId,
+      phaseTitle,
+      runSource
    );
    requestBody.run_try_id = runtimeMeta?.tryId;
    if (run?.id) {

--- a/frontend/src/utils/statsConversation.ts
+++ b/frontend/src/utils/statsConversation.ts
@@ -1,0 +1,84 @@
+import { format } from "date-fns";
+
+export type ConversationMessage = {
+  timestamp: string;
+  user_id?: number | null;
+  /** Backend JSONField — string, object, or message list */
+  system_prompt: unknown;
+  phase_instructions: string;
+  user_prompt: string;
+  response: string;
+  rubric: string;
+  scored_run?: boolean;
+  /** Raw stored score (JSON dict, number, or LLM prose + JSON) */
+  run_score: unknown;
+  /** Parsed total from backend when available */
+  score_total?: number | null;
+  run_passed: boolean | null;
+  credits?: number | null;
+  minimum_score?: number | null;
+  score_feedback?: string;
+};
+
+/** Collapse long system prompts in the conversation details dialog */
+export const SYSTEM_PROMPT_COLLAPSE_CHARS = 400;
+
+/** Turn Run.system_prompt JSON into readable text for exports and dialog */
+export function formatStoredPrompt(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value.trim();
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((item) => {
+        if (item == null) return "";
+        if (typeof item === "string") return item.trim();
+        if (typeof item === "object" && item !== null && "content" in item) {
+          const c = (item as { content?: unknown }).content;
+          return typeof c === "string" ? c.trim() : "";
+        }
+        return "";
+      })
+      .filter(Boolean);
+    if (parts.length) return parts.join("\n\n");
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return "";
+    }
+  }
+  if (typeof value === "object") {
+    const o = value as Record<string, unknown>;
+    if (typeof o.content === "string" && o.content.trim())
+      return o.content.trim();
+    if (typeof o.text === "string" && o.text.trim()) return o.text.trim();
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}
+
+export function formatConversationTimestamp(timestamp: string): string {
+  return format(new Date(timestamp), "MMM d, yyyy HH:mm:ss");
+}
+
+export function formatConversationHeaderTimestamp(timestamp: string): string {
+  return format(new Date(timestamp), "dd.MM.yyyy, HH:mm:ss");
+}
+
+/** First non-empty formatted system prompt in the session */
+export function getSessionSystemPromptText(
+  messages: ConversationMessage[] | undefined
+): string {
+  if (!messages?.length) return "";
+  for (const m of messages) {
+    const t = formatStoredPrompt(m.system_prompt);
+    if (t) return t;
+  }
+  return "";
+}

--- a/frontend/src/utils/statsConversation.ts
+++ b/frontend/src/utils/statsConversation.ts
@@ -5,8 +5,14 @@ export type ConversationMessage = {
   user_id?: number | null;
   /** Backend JSONField — string, object, or message list */
   system_prompt: unknown;
-  phase_instructions: string;
-  user_prompt: string;
+  /** Phase / chatbot instructions (JSONField) */
+  phase_instructions: unknown;
+  /** Survey phase title when the run was created */
+  phase_title?: string;
+  /** Explicit marker: run originated from chat component */
+  is_chat_run?: boolean;
+  /** Final user prompt / chat line (JSONField) */
+  user_prompt: unknown;
   response: string;
   rubric: string;
   scored_run?: boolean;
@@ -22,6 +28,61 @@ export type ConversationMessage = {
 
 /** Collapse long system prompts in the conversation details dialog */
 export const SYSTEM_PROMPT_COLLAPSE_CHARS = 400;
+
+/** Collapse long chat-instruction blocks (Figma: Chat Instructions + Show more) */
+export const CHAT_INSTRUCTIONS_COLLAPSE_CHARS = 400;
+
+export type ConversationPhaseGroup = {
+  mergeKey: string;
+  phaseTitle: string;
+  messages: ConversationMessage[];
+};
+
+/** Stable key for grouping runs in the same phase / chat session */
+export function phaseInstructionsKey(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Group only chat runs (`is_chat_run=true`) when they are consecutive and share
+ * the same phase title + phase instructions. Non-chat runs stay one-per-group.
+ */
+export function groupConversationMessagesByPhase(
+  rows: ConversationMessage[]
+): ConversationPhaseGroup[] {
+  const groups: ConversationPhaseGroup[] = [];
+  rows.forEach((row, idx) => {
+    if (!row.is_chat_run) {
+      groups.push({
+        mergeKey: `single:${idx}`,
+        phaseTitle: (row.phase_title ?? "").trim(),
+        messages: [row],
+      });
+      return;
+    }
+
+    const title = (row.phase_title ?? "").trim();
+    const ik = phaseInstructionsKey(row.phase_instructions);
+    const mergeKey = `${title}\0${ik}`;
+    const last = groups[groups.length - 1];
+    if (last && last.mergeKey === mergeKey) {
+      last.messages.push(row);
+    } else {
+      groups.push({
+        mergeKey,
+        phaseTitle: (row.phase_title ?? "").trim(),
+        messages: [row],
+      });
+    }
+  });
+  return groups;
+}
 
 /** Turn Run.system_prompt JSON into readable text for exports and dialog */
 export function formatStoredPrompt(value: unknown): string {


### PR DESCRIPTION
[Issue](https://github.com/onmicroai/micro_ai/issues/263)

## Summary

Redesigned the **conversation details dialog** and improved chat run tracking, score handling, and overall maintainability.

- Updated conversation UI to match Figma:
  - Figma-style user/assistant bubbles (avatars, backgrounds, spacing, typography)
  - System Prompt section with smooth expand/collapse
  - Chat Instructions section with expand/collapse and “Show more / less”
  - Metadata row and improved layout consistency

- Introduced chat phase grouping:
  - New Chat Phase Card layout for grouped chatbot runs
  - Grouping based on `is_chat_run=true`
  - Non-chat runs remain standalone

- Fixed score rendering:
  - `run_score` may contain raw LLM prose or JSON
  - UI now displays numeric total (`score_total` or parsed value)
  - Full scoring explanation preserved in feedback section

- Added explicit chat run tracking:
  - Persisted `Run.is_chat_run` from frontend (`runSource: "chat"`)
  - Conversation analytics endpoint returns `is_chat_run`

- Added phase context support:
  - Persisted `phase_title` per run
  - Included in conversation details response
  - Frontend sends `phase_title` from current phase

- Refactored conversation dialog for maintainability:
  - Extracted components:
    - `ConversationBubble`
    - `ConversationDetailsDialog`
    - `ChatPhaseCard`
    - `ConversationTurnBlock`
    - `ChatInstructionsCollapsible`
  - Moved shared helpers and types into `statsConversation` utils

- Updated frontend container startup behavior:
  - Runs `yarn install && ...` on container start
  - Ensures dependency updates when using bind mounts + `/frontend/node_modules`

---

## Backend changes

### Run model

- Added:
  - `phase_title`
  - `is_chat_run`

### Run views

- Persist:
  - `phase_title`
  - `is_chat_run` in `run_data`

### Analytics views

- Conversation details response now includes:
  - `phase_title`
  - `is_chat_run`
  - `score_total` (parsed numeric score)

### Score parsing

- Introduced shared parser utility for `run_score`
- Unified normalization and extraction logic
- `extract_score` now uses shared parser

---

## Frontend changes

### Conversation dialog

- Figma-aligned rendering and layout
- Chat phase grouping support
- Smooth collapsible animations for:
  - System Prompt
  - Chat Instructions

### Request / data flow

- `buildRequestBody` now sends:
  - `phase_title`
  - `is_chat_run`

- `sendPromptsUtil` supports:
  - `runSource`

- `ChatQuestion` sets:
  - `runSource: "chat"`

### Data normalization / export

- Normalize:
  - `system_prompt`
  - `user_prompt`

- Score export uses:
  - Parsed numeric score

---

## Notes

- Chat grouping is strictly based on `is_chat_run=true`
- Non-chat runs are intentionally not grouped
- Score rendering is now stable regardless of LLM output format (JSON/prose)

---

## Demo


https://github.com/user-attachments/assets/01c85d81-cff9-4c0d-97e5-fd663734add9

