### PR TITLE
Fix app time statistic getting

### DIFF
--- a/backend/apps/microapps/views/analytics_views.py
+++ b/backend/apps/microapps/views/analytics_views.py
@@ -258,6 +258,36 @@ class AppStatistics(APIView):
                     runs[0]['satisfaction_percent'] = 0
                     runs[0]['likes_percent'] = 0
                     runs[0]['dislikes_percent'] = 0
+            else:
+                # Usage-based time-in-app does not require Run rows; still return one row for the UI.
+                themes, generated_at = get_latest_themes_for_app(app_id)
+                runs = [{
+                    'ma_id': app_id,
+                    'net_satisfaction_score': 0,
+                    'thumbs_up_count': 0,
+                    'thumbs_down_count': 0,
+                    'total_responses': 0,
+                    'total_cost': 0,
+                    'total_credits': 0,
+                    'unique_users': 0,
+                    'sessions': 0,
+                    'avg_cost_session': 0,
+                    'avg_credits_session': 0,
+                    'avg_session_seconds': avg_session_seconds,
+                    'min_session_seconds': min_session_seconds,
+                    'max_session_seconds': max_session_seconds,
+                    'themes': themes,
+                    'themes_generated_at': generated_at,
+                    'avg_credits_per_run': 0,
+                    'min_credits_per_run': 0,
+                    'max_credits_per_run': 0,
+                    'pass_rate_percent': 0,
+                    'pass_percent': 0,
+                    'fail_percent': 0,
+                    'satisfaction_percent': 0,
+                    'likes_percent': 0,
+                    'dislikes_percent': 0,
+                }]
 
             return Response({"data": runs, "status": status.HTTP_200_OK}, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
[Issue](https://github.com/onmicroai/micro_ai/issues/323)

Summary

  The app statistics API (GET /api/microapps/stats/run) previously returned {"data": []} whenever an app had no Run records, even
   when AppUsageSession rows existed from normal usage tracking. Session length metrics are derived from usage sessions, not from
   runs, so that behavior was inconsistent with the product's meaning of “time in app.”

  This change returns one stats row when there are no runs: run-based aggregates stay at zero, while average / min / max session 
  duration (and themes) are still populated from AppUsageSession, matching the UI expectations on the microapp statistics page.


What changed

  • backend/apps/microapps/views/analytics_views.py — In AppStatistics.get, when the run aggregate is empty, build a single
    response object with the same shape as the existing run-based row (zeros for run/credit/pass/satisfaction fields) and
    attach avg_session_seconds, min_session_seconds, max_session_seconds from usage-session aggregation, plus themes /
    themes_generated_at from the existing helper.


  How app time tracking works (overview)

  1. Client (runtime)

     When a user opens a microapp in the normal runtime (not builder preview), the client starts a usage session by POSTing to
  /api/microapps/stats/usage-session/start with the app hash_id. The server creates an AppUsageSession row and returns a
  session_id.

  2. Heartbeats

     While the tab is visible, the client sends periodic POSTs to /api/microapps/stats/usage-session/heartbeat with hash_id and
  session_id. The server updates last_seen_at on the open session so “active time” can be inferred if the user leaves without a
  clean end.

  3. End

     On navigation away or unload, the client ends the session via POST /api/microapps/stats/usage-session/end (or sendBeacon for
   the end URL when appropriate). The server sets ended_at (and last_seen_at) on that session.

  4. Statistics

     For analytics, session length is computed per AppUsageSession: an effective end time is ended_at, or if missing,
  last_seen_at, or started_at. Durations shorter than MIN_USAGE_DURATION_SECONDS (5 seconds) are ignored when computing aggregate
   min/avg/max, to filter noise.

  5. Separation from “runs”

     Runs (Run) record AI interactions (prompts, credits, sessions of model calls, etc.). Usage sessions track wall-clock 
  presence in the app regardless of whether any run occurred. Stats for “time in app” therefore do not require any finished or
  started AI run; they only require usage-session data.